### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+        "GitHub Skills": {
+            "description": "Hands-on GitHub training covering collaboration, pull requests, and GitHub Skills badges.",
+            "schedule": "One-week intensive — signups open now; sessions across the week",
+            "max_participants": 25,
+            "participants": []
+        },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
Quick add: include a `GitHub Skills` activity in `src/app.py` so students can register. This is a short-term fix — later we'll migrate activities to persistent storage.